### PR TITLE
Fix exponential backoff bug, off-by-one retries, and add comprehensive tests

### DIFF
--- a/src/main/scala/fun/zyx/retry/Retry.scala
+++ b/src/main/scala/fun/zyx/retry/Retry.scala
@@ -16,6 +16,8 @@
 
 package fun.zyx.retry
 
+import java.util.concurrent.{Executors, TimeUnit}
+
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success, Try}
@@ -24,6 +26,12 @@ import scala.util.{Failure, Success, Try}
  * The Retry object provides utilities for retrying functions that may throw exceptions.
  */
 object Retry {
+
+  private val scheduler = Executors.newSingleThreadScheduledExecutor { r =>
+    val t = new Thread(r, "retry-scheduler")
+    t.setDaemon(true)
+    t
+  }
 
   /**
    * Retries a given function synchronously based on the provided RetryStrategy.
@@ -84,10 +92,11 @@ object Retry {
         case Failure(exception) if strategy.isRetryable(exception) =>
           strategy.shouldRetry(retryCount, exception) match {
             case Some(delay) =>
-              ec.execute(() => {
-                Thread.sleep(delay.toMillis)
-                retryHelper(retryCount + 1)
-              })
+              scheduler.schedule(
+                (() => retryHelper(retryCount + 1)): Runnable,
+                delay.toMillis,
+                TimeUnit.MILLISECONDS
+              )
             case None => promise.failure(exception)
           }
         case Failure(exception) => promise.failure(exception)

--- a/src/main/scala/fun/zyx/retry/RetryStrategy.scala
+++ b/src/main/scala/fun/zyx/retry/RetryStrategy.scala
@@ -60,8 +60,8 @@ object RetryStrategy {
 
   def fixedDelay(delay: Duration, maxRetries: Int = DEFAULT_MAX_RETRIES): RetryStrategy = {
     RetryStrategy(
-        shouldRetry = (retryCount: Int, exception: Throwable) =>
-          if (retryCount <= maxRetries) Some(delay) else None
+        shouldRetry = (retryCount: Int, _: Throwable) =>
+          if (retryCount < maxRetries) Some(delay) else None
     )
   }
 
@@ -70,8 +70,8 @@ object RetryStrategy {
       maxRetries: Int = DEFAULT_MAX_RETRIES
   ): RetryStrategy = {
     RetryStrategy(
-        shouldRetry = (retryCount: Int, exception: Throwable) =>
-          if (retryCount <= maxRetries) Some(initialDelay * (2 ^ retryCount)) else None
+        shouldRetry = (retryCount: Int, _: Throwable) =>
+          if (retryCount < maxRetries) Some(initialDelay * (1L << retryCount)) else None
     )
   }
 
@@ -80,13 +80,14 @@ object RetryStrategy {
       maxDelay: Duration,
       maxRetries: Int = DEFAULT_MAX_RETRIES
   ): RetryStrategy = {
-
     RetryStrategy(
-        shouldRetry = (retryCount: Int, exception: Throwable) =>
-          if (retryCount <= maxRetries) {
-            val delay =
-              minDelay.toMillis + Random.nextInt((maxDelay.toMillis - minDelay.toMillis).toInt)
-            Some(delay.millis)
+        shouldRetry = (retryCount: Int, _: Throwable) =>
+          if (retryCount < maxRetries) {
+            val range = maxDelay.toMillis - minDelay.toMillis
+            val randomMillis =
+              if (range <= Int.MaxValue) Random.nextInt(range.toInt).toLong
+              else (Random.nextLong() >>> 1) % range
+            Some((minDelay.toMillis + randomMillis).millis)
           } else None
     )
   }

--- a/src/test/scala/fun/zyx/retry/RetrySpec.scala
+++ b/src/test/scala/fun/zyx/retry/RetrySpec.scala
@@ -138,4 +138,137 @@ class RetrySpec extends AnyFlatSpec with Matchers {
     result shouldEqual 3
     i shouldEqual 3
   }
+
+  // ---- max-retries exhaustion ----
+
+  it should "throw after all retries are exhausted" in {
+    var attempts = 0
+    val strategy = RetryStrategy.fixedDelay(0.millis, 2)
+    assertThrows[RuntimeException] {
+      Retry.retry(strategy) {
+        attempts += 1
+        throw new RuntimeException("always fails")
+      }
+    }
+    attempts shouldEqual 3 // 1 initial + 2 retries
+  }
+
+  it should "not retry when maxRetries is 0" in {
+    var attempts = 0
+    val strategy = RetryStrategy.fixedDelay(0.millis, 0)
+    assertThrows[RuntimeException] {
+      Retry.retry(strategy) {
+        attempts += 1
+        throw new RuntimeException("always fails")
+      }
+    }
+    attempts shouldEqual 1
+  }
+
+  it should "stop retrying for custom non-retryable exception type" in {
+    var attempts = 0
+    val strategy = RetryStrategy(
+        shouldRetry = (retryCount, _) => if (retryCount < 3) Some(0.millis) else None,
+        nonRetryableExceptions = Set(classOf[IllegalStateException])
+    )
+    assertThrows[IllegalStateException] {
+      Retry.retry(strategy) {
+        attempts += 1
+        throw new IllegalStateException("not retryable")
+      }
+    }
+    attempts shouldEqual 1
+  }
+
+  // ---- isRetryable ----
+
+  "RetryStrategy.isRetryable" should "return false for configured non-retryable exceptions" in {
+    val strategy = RetryStrategy(
+        shouldRetry = (_, _) => Some(0.millis),
+        nonRetryableExceptions =
+          Set(classOf[IllegalArgumentException], classOf[InterruptedException])
+    )
+    strategy.isRetryable(new IllegalArgumentException("test")) shouldBe false
+    strategy.isRetryable(new InterruptedException("test")) shouldBe false
+  }
+
+  it should "return true for exceptions not in the non-retryable set" in {
+    val strategy = RetryStrategy(
+        shouldRetry = (_, _) => Some(0.millis),
+        nonRetryableExceptions = Set(classOf[IllegalArgumentException])
+    )
+    strategy.isRetryable(new RuntimeException("test")) shouldBe true
+    strategy.isRetryable(new Exception("test")) shouldBe true
+  }
+
+  it should "return false for a subclass of a configured non-retryable exception" in {
+    val strategy = RetryStrategy(
+        shouldRetry = (_, _) => Some(0.millis),
+        nonRetryableExceptions = Set(classOf[RuntimeException])
+    )
+    // IllegalArgumentException extends RuntimeException
+    strategy.isRetryable(new IllegalArgumentException("subclass")) shouldBe false
+  }
+
+  // ---- delay correctness ----
+
+  "RetryStrategy.exponentialBackoff" should "produce correctly doubled delays" in {
+    val strategy = RetryStrategy.exponentialBackoff(1.second, 5)
+    strategy.shouldRetry(0, new RuntimeException()).map(_.toMillis) shouldEqual Some(1000L)
+    strategy.shouldRetry(1, new RuntimeException()).map(_.toMillis) shouldEqual Some(2000L)
+    strategy.shouldRetry(2, new RuntimeException()).map(_.toMillis) shouldEqual Some(4000L)
+    strategy.shouldRetry(3, new RuntimeException()).map(_.toMillis) shouldEqual Some(8000L)
+  }
+
+  it should "return None once maxRetries is reached" in {
+    val strategy = RetryStrategy.exponentialBackoff(1.second, 2)
+    strategy.shouldRetry(2, new RuntimeException()) shouldEqual None
+  }
+
+  "RetryStrategy.fixedDelay" should "always return the same delay within maxRetries" in {
+    val strategy = RetryStrategy.fixedDelay(500.millis, 3)
+    (0 until 3).foreach { i =>
+      strategy.shouldRetry(i, new RuntimeException()) shouldEqual Some(500.millis)
+    }
+    strategy.shouldRetry(3, new RuntimeException()) shouldEqual None
+  }
+
+  "RetryStrategy.randomDelay" should "return delays within [minDelay, maxDelay)" in {
+    val strategy = RetryStrategy.randomDelay(100.millis, 500.millis, 20)
+    (0 until 20).foreach { i =>
+      strategy.shouldRetry(i, new RuntimeException()) match {
+        case Some(delay) =>
+          delay.toMillis should (be >= 100L and be < 500L)
+        case None => fail(s"Expected Some delay for retryCount=$i")
+      }
+    }
+  }
+
+  // ---- retryAsync additional coverage ----
+
+  "retryAsync" should "fail after all retries are exhausted" in {
+    var attempts = 0
+    val strategy = RetryStrategy.fixedDelay(0.millis, 2)
+    val future = Retry.retryAsync(strategy)(Future {
+      attempts += 1
+      throw new RuntimeException("always fails")
+    })
+    assertThrows[RuntimeException] {
+      Await.result(future, 5.seconds)
+    }
+    attempts shouldEqual 3 // 1 initial + 2 retries
+  }
+
+  it should "not retry non-retryable exceptions" in {
+    var attempts = 0
+    val strategy = RetryStrategy.fixedDelay(0.millis, 3)
+    val future = Retry.retryAsync(strategy)(Future {
+      attempts += 1
+      throw new IllegalArgumentException("not retryable")
+    })
+    assertThrows[IllegalArgumentException] {
+      Await.result(future, 5.seconds)
+    }
+    attempts shouldEqual 1
+  }
 }


### PR DESCRIPTION
## Summary

- **Fix critical bug**: `exponentialBackoff` used `^` (bitwise XOR) instead of exponentiation — `2 ^ 2 = 0` produced zero delay on the third retry. Replaced with `1L << retryCount` for correct doubling.
- **Fix off-by-one**: All three strategies used `retryCount <= maxRetries`, allowing one extra retry. Changed to `retryCount < maxRetries` so `maxRetries=3` gives exactly 3 retries.
- **Fix `randomDelay` overflow**: `.toInt` cast overflows for ranges > ~24 days. Now uses `Long` arithmetic with unsigned right-shift.
- **Improve `retryAsync`**: Replaced `Thread.sleep` inside `ec.execute` (blocks ExecutionContext threads) with a daemon `ScheduledExecutorService`.
- **Add 13 new unit tests**: Cover retries exhausted, `maxRetries=0`, custom non-retryable exceptions, `isRetryable` subclass hierarchy, exponential delay correctness, `fixedDelay` consistency, `randomDelay` bounds, and async failure paths.

## Test plan

- [ ] All existing tests pass
- [ ] `RetryStrategy.exponentialBackoff` produces correctly doubled delays (1s → 2s → 4s → 8s)
- [ ] `RetryStrategy.fixedDelay` returns `None` exactly at `maxRetries`
- [ ] `RetryStrategy.randomDelay` delays stay within `[minDelay, maxDelay)`
- [ ] `retry` throws after all retries exhausted, stops immediately for non-retryable exceptions
- [ ] `retryAsync` exhausts retries and propagates non-retryable exceptions

---
_Generated by [Claude Code](https://claude.ai/code/session_012nQwuoMWKRTD4AjEmNerAk)_