### PR TITLE
Upgrade CI actions to v5 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'


### PR DESCRIPTION
## Problem

`actions/checkout@v4` and `actions/setup-java@v4` target Node.js 20, which is deprecated and will be removed from GitHub Actions runners on **September 16th, 2026**.

## Fix

Upgrade both actions to `@v5` which natively targets Node.js 24, eliminating the deprecation warning.

## Note

Will **not** merge until CI passes cleanly with no warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_012nQwuoMWKRTD4AjEmNerAk)_